### PR TITLE
delete image versions too

### DIFF
--- a/upload_server.js
+++ b/upload_server.js
@@ -146,6 +146,14 @@ UploadServer = {
 
     // make sure paths are correct
     fs.unlinkSync(path.join(options.uploadDir, filePath));
+    
+    // unlink all imageVersions also
+    if (options.imageVersions) {
+    	var subFolders = Object.keys(options.imageVersions);
+ 	for(var i=0; i<subFolders.length; i++) {
+	    fs.unlinkSync(path.join(options.uploadDir, subFolders[i], filePath));
+ 	}
+    }
   },
   serve: function (req, res) {
     if (options.tmpDir == null || options.uploadDir == null) {


### PR DESCRIPTION
The current delete method deletes only the uploaded file and note the associated versions.
